### PR TITLE
updated quotation marks to resemble UTF-8

### DIFF
--- a/RingBuf.h
+++ b/RingBuf.h
@@ -47,7 +47,7 @@
     #else
         #define RB_ATOMIC_START {
         #define RB_ATOMIC_END }
-        #warning “This library only fully supports AVR and ESP8266 Boards.”
+        #warning "This library only fully supports AVR and ESP8266 Boards."
         #warning "Operations on the buffer in ISRs are not safe!"
     #endif
 


### PR DESCRIPTION
In order to get my compiler to work correctly, i had to change the quotation marks of the warning to the correct ones.