### PR TITLE
added error none exclusion

### DIFF
--- a/ESPAsyncE131.cpp
+++ b/ESPAsyncE131.cpp
@@ -179,7 +179,7 @@ void ESPAsyncE131::parsePacket(AsyncUDPPacket _packet)
 
     } while(false);
 
-    if (error != ERROR_IGNORE)
+    if (error != ERROR_IGNORE && error != ERROR_NONE)
     {
         if (Serial)
         {


### PR DESCRIPTION
Issue #33 

Since `error` is assigned the value of `ERROR_NONE` at the start, if no errors were encountered during packet parsing the `ERROR_NONE` is also counter as an error in stats. This addition to the condition prevents that from happening.