### PR TITLE
Fix AsyncUDP dependency platform array

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,6 +17,6 @@
   "headers": "ESPAsyncE131.h",
   "dependencies": {
     "name": "ESPAsyncUDP",
-    "platforms": "espressif8266"
+    "platforms": ["espressif8266"]
   }
 }


### PR DESCRIPTION
When the platform for AsyncUDP is specified as a string, PIO still tries to download the dependency even in ESP32. Making it an array seems to fix it.


Addresses issue #32 