### PR TITLE
Fix error counter

### DIFF
--- a/ESPAsyncE131.cpp
+++ b/ESPAsyncE131.cpp
@@ -190,7 +190,7 @@ void ESPAsyncE131::parsePacket(AsyncUDPPacket _packet)
 
     } while(false);
 
-    if (error != ERROR_IGNORE)
+    if (error != ERROR_IGNORE && error != ERROR_NONE)
     {
         if (Serial)
         {

--- a/library.json
+++ b/library.json
@@ -17,6 +17,6 @@
   "headers": "ESPAsyncE131.h",
   "dependencies": {
     "name": "ESPAsyncUDP",
-    "platforms": "espressif8266"
+    "platforms": ["espressif8266"]
   }
 }


### PR DESCRIPTION
ERROR_NONE leads to incrementing the error counter, but ERROR_NONE is not an error. This resolves the issue. Built on PR #39.